### PR TITLE
[Discussion] Adding VS Live Share

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,9 @@ This extension pack packages some of the most popular (and some of my favorite) 
 * [EditorConfig for VS Code](https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig)
   * There is a **EditorConfig: Generate** can generate `.editorconfig` on the fly.
 
+* [VS Live Share](https://marketplace.visualstudio.com/items?itemName=MS-vsliveshare.vsliveshare)
+  * Adds real-time collaborative editing and debugging into VS Code.
+
 ### Workbench
 
 * [VSCode simpler Icons with Angular](https://marketplace.visualstudio.com/items?itemName=davidbabel.vscode-simpler-icons)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "xabikos.JavaScriptSnippets",
         "eg2.tslint",
         "MariusAlchimavicius.json-to-ts",
-        "joelday.docthis"
+        "joelday.docthis",
+        "MS-vsliveshare.vsliveshare"
     ]
 }


### PR DESCRIPTION
This PR proposes adding [Visual Studio Live Share](aka.ms/vsls) to this extension pack, since it's optimized for JavaScript/Angular development, and supports common collaboration use cases for web devs (e.g. pair programming, hack-a-thons, remote code reviews). 

// CC @doggy8088