### PR TITLE
feat: add Angular Schematics extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,9 @@ This extension pack packages some of the most popular (and some of my favorite) 
   * Remember to hit `F12` that **Go To** css file and open in a new editor.
   * Remember to hit `Ctrl` to show the definition when hovering over the symbol.
 
+* [Angular Schematics](https://marketplace.visualstudio.com/items?itemName=cyrilletuzi.angular-schematics)
+  * Allows you to launch Angular schematics (CLI commands) from files Explorer (right-click) or Command Palette.
+
 ### Code Analysis
 
 * [TSLint](https://marketplace.visualstudio.com/items?itemName=eg2.tslint)

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "xabikos.JavaScriptSnippets",
         "eg2.tslint",
         "MariusAlchimavicius.json-to-ts",
-        "joelday.docthis"
+        "joelday.docthis",
+        "cyrilletuzi.angular-schematics"
     ]
 }


### PR DESCRIPTION
Hi @doggy8088,

I did a GUI tool for Angular schematics / CLI commands for VS Code. It was done to improve productivity, so I think it would really fit in this Angular extension pack.

You can test the extension here: [https://marketplace.visualstudio.com/items?itemName=cyrilletuzi.angular-schematics](https://marketplace.visualstudio.com/items?itemName=cyrilletuzi.angular-schematics)

If you think it's a good extension, this PR adds it to your extension pack. Otherwise, I would appreciate feedback. Thanks.