### PR TITLE
Set the correct vscode engine compatibiltiy

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "icon": "icon.png",
     "repository": "https://github.com/doggy8088/angular-extension-pack",
     "engines": {
-        "vscode": "^1.20.0"
+        "vscode": "^1.26.0"
     },
     "categories": [
         "Extension Packs"


### PR DESCRIPTION
vscode engine should be set to `^1.26` because older VS Code versions does not support `extensionPack` property

@doggy8088 Please have this change before publishing the extension